### PR TITLE
Add comprehensive frontend unit test suite

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,7 +14,19 @@
         "react-scripts": "5.0.1",
         "socket.io-client": "^4.8.1",
         "web-vitals": "^5.1.0"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -3421,6 +3433,107 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -3429,6 +3542,14 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6126,6 +6247,13 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssdb": {
       "version": "7.11.2",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.11.2.tgz",
@@ -6482,6 +6610,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -6595,6 +6734,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -9180,6 +9327,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -11183,6 +11340,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -11347,6 +11515,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mini-css-extract-plugin": {
@@ -14023,6 +14201,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -15459,6 +15651,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/web/package.json
+++ b/web/package.json
@@ -33,5 +33,10 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/web/src/App.test.js
+++ b/web/src/App.test.js
@@ -1,8 +1,285 @@
-import { render, screen } from '@testing-library/react';
+/**
+ * Tests for the App root component.
+ * Verifies authentication flow, socket lifecycle, screen routing, and event handling.
+ */
+import React from 'react';
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
+
+// Build the mock socket fresh for each test via a factory.
+// We store the "current" mock socket in a module-level variable that gets
+// reassigned in beforeEach, so the jest.mock factory always returns the latest one.
+let mockCurrentSocket;
+let mockCurrentHandlers;
+
+function buildMockSocket() {
+  const handlers = {};
+  const socket = {
+    on: jest.fn((event, handler) => {
+      if (!handlers[event]) handlers[event] = [];
+      handlers[event].push(handler);
+    }),
+    emit: jest.fn(),
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    connected: true
+  };
+  return { socket, handlers };
+}
+
+function simulateSocketEvent(event, data) {
+  if (mockCurrentHandlers[event]) {
+    mockCurrentHandlers[event].forEach(h => h(data));
+  }
+}
+
+// Mock socket.io-client to return whatever mockCurrentSocket is set to.
+jest.mock('socket.io-client', () => {
+  // This factory runs once, but the returned fn closes over the module-level variable
+  // which gets reassigned each beforeEach.
+  return function mockIo() {
+    return mockCurrentSocket;
+  };
+});
+
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+describe('App', () => {
+  beforeEach(() => {
+    const { socket, handlers } = buildMockSocket();
+    mockCurrentSocket = socket;
+    mockCurrentHandlers = handlers;
+
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+    console.log.mockRestore();
+    console.error.mockRestore();
+    global.fetch = undefined;
+  });
+
+  /**
+   * Set up fetch to handle login (first call) and subsequent GameLobby fetches.
+   */
+  function setupFetchForLoginAndLobby() {
+    let callCount = 0;
+    global.fetch = jest.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            success: true,
+            data: { player_id: 'uuid-1', username: 'testuser', session_token: 'token123' }
+          }),
+          text: () => Promise.resolve('{}')
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ success: true, data: { games: [], total_games: 0 } }),
+        text: () => Promise.resolve('{}')
+      });
+    });
+  }
+
+  /**
+   * Log in and connect socket, advancing to the lobby screen.
+   */
+  async function loginAndConnect() {
+    setupFetchForLoginAndLobby();
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    const loginBtn = screen.getByText(/Join Game Lobby/);
+    await act(async () => {
+      fireEvent.click(loginBtn);
+    });
+
+    await act(async () => {
+      simulateSocketEvent('connect');
+      simulateSocketEvent('connected', { message: 'Successfully connected' });
+    });
+  }
+
+  /**
+   * Enter a game from the lobby via game_state socket event.
+   */
+  async function enterGame() {
+    const gameState = {
+      game_id: 'TEST1',
+      game_type: 'grab',
+      status: 'active',
+      current_turn: 1,
+      turn_time_remaining: null,
+      players: {
+        testuser: { connected: true, score: 0, ready_for_next_turn: false }
+      },
+      state: JSON.stringify({
+        num_players: 1,
+        pool: new Array(26).fill(0),
+        bag: new Array(26).fill(0),
+        words_per_player: [[]],
+        scores: [0],
+        passed: [false]
+      })
+    };
+
+    await act(async () => {
+      simulateSocketEvent('game_state', { data: gameState });
+    });
+
+    return gameState;
+  }
+
+  test('shows login screen initially', () => {
+    render(<App />);
+    expect(screen.getByText(/Join Game Lobby/)).toBeInTheDocument();
+  });
+
+  test('login sends POST to auth endpoint', async () => {
+    setupFetchForLoginAndLobby();
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(/Join Game Lobby/));
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/auth/login'),
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  test('login failure shows error status', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 409,
+        text: () => Promise.resolve('Username taken'),
+        json: () => Promise.resolve({ success: false, error: 'Username taken' })
+      })
+    );
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(/Join Game Lobby/));
+    });
+
+    expect(screen.getByText(/Login failed/)).toBeInTheDocument();
+  });
+
+  test('after connection, shows lobby with Disconnect button', async () => {
+    await loginAndConnect();
+
+    expect(screen.getByText('Disconnect')).toBeInTheDocument();
+    expect(screen.getByText(/Game Lobby/)).toBeInTheDocument();
+  });
+
+  test('socket game_state event switches to GameInterface', async () => {
+    await loginAndConnect();
+    await enterGame();
+
+    expect(screen.getByText(/Game TEST1/)).toBeInTheDocument();
+  });
+
+  test('socket move_result with error adds error event', async () => {
+    await loginAndConnect();
+    await enterGame();
+
+    await act(async () => {
+      simulateSocketEvent('move_result', {
+        success: false,
+        error: "Word 'xyz' is not in the allowed word list"
+      });
+    });
+
+    expect(screen.getByText(/Word 'xyz' is not in the allowed word list/)).toBeInTheDocument();
+  });
+
+  test('socket player_disconnected adds connection event', async () => {
+    await loginAndConnect();
+    await enterGame();
+
+    await act(async () => {
+      simulateSocketEvent('player_disconnected', { player: 'otherPlayer' });
+    });
+
+    expect(screen.getByText(/otherPlayer disconnected/)).toBeInTheDocument();
+  });
+
+  test('socket player_reconnected adds connection event', async () => {
+    await loginAndConnect();
+    await enterGame();
+
+    await act(async () => {
+      simulateSocketEvent('player_reconnected', { player: 'otherPlayer' });
+    });
+
+    expect(screen.getByText(/otherPlayer reconnected/)).toBeInTheDocument();
+  });
+
+  test('socket game_ended returns to lobby', async () => {
+    await loginAndConnect();
+    await enterGame();
+
+    await act(async () => {
+      simulateSocketEvent('game_ended', { ended_by: 'host', reason: 'Game ended by creator' });
+    });
+
+    expect(screen.getByText(/Game Lobby/)).toBeInTheDocument();
+  });
+
+  test('turn_starting adds game event', async () => {
+    await loginAndConnect();
+    await enterGame();
+
+    await act(async () => {
+      simulateSocketEvent('turn_starting', {
+        turn_number: 2,
+        letters_drawn: ['e'],
+        time_limit: 300,
+        letters_remaining_in_bag: 85
+      });
+    });
+
+    expect(screen.getByText(/Turn 2 starting/)).toBeInTheDocument();
+  });
+
+  test('turn_ending adds game event', async () => {
+    await loginAndConnect();
+    await enterGame();
+
+    await act(async () => {
+      simulateSocketEvent('turn_ending', {
+        turn_number: 1,
+        reason: 'all_players_passed',
+        final_moves_count: 3
+      });
+    });
+
+    expect(screen.getByText(/Turn 1 ended.*All players passed/)).toBeInTheDocument();
+  });
+
+  test('disconnect button returns to login screen', async () => {
+    await loginAndConnect();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Disconnect'));
+    });
+
+    expect(screen.getByText(/Join Game Lobby/)).toBeInTheDocument();
+  });
 });

--- a/web/src/GameInterface.test.js
+++ b/web/src/GameInterface.test.js
@@ -1,0 +1,122 @@
+/**
+ * Tests for the GameInterface component.
+ * Verifies game layout rendering, state display, and user interactions.
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import GameInterface from './GameInterface';
+import { createMockGameState, createMockSocket, mockFetchSuccess } from './testUtils';
+
+describe('GameInterface', () => {
+  let mockSocket;
+
+  const createDefaultProps = (overrides = {}) => ({
+    gameState: createMockGameState(),
+    socket: mockSocket,
+    currentUsername: 'player1',
+    authToken: 'test-token',
+    serverUrl: 'http://localhost:5001',
+    gameEvents: [],
+    gameCreator: 'player1',
+    onAddGameEvent: jest.fn(),
+    onLeaveGame: jest.fn(),
+    ...overrides
+  });
+
+  beforeEach(() => {
+    mockSocket = createMockSocket();
+    jest.clearAllMocks();
+    // Suppress console.log/error from component
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    console.log.mockRestore();
+    console.error.mockRestore();
+    if (global.fetch) {
+      global.fetch = undefined;
+    }
+  });
+
+  test('shows loading when gameState is null', () => {
+    render(<GameInterface {...createDefaultProps({ gameState: null })} />);
+    expect(screen.getByText(/Loading game/)).toBeInTheDocument();
+  });
+
+  test('renders game ID in header', () => {
+    render(<GameInterface {...createDefaultProps()} />);
+    expect(screen.getByText(/Game TEST1/)).toBeInTheDocument();
+  });
+
+  test('renders game status in header', () => {
+    render(<GameInterface {...createDefaultProps()} />);
+    expect(screen.getByText(/ACTIVE/)).toBeInTheDocument();
+  });
+
+  test('renders turn info in header', () => {
+    render(<GameInterface {...createDefaultProps()} />);
+    expect(screen.getByText(/Turn: 1/)).toBeInTheDocument();
+  });
+
+  test('shows remaining letters count', () => {
+    render(<GameInterface {...createDefaultProps()} />);
+    // The bag has letters, so "Remaining letters" should appear with a count
+    expect(screen.getByText(/Remaining letters/)).toBeInTheDocument();
+  });
+
+  test('shows "Start Game" button for creator in waiting state', () => {
+    const gameState = createMockGameState({ status: 'waiting' });
+    render(<GameInterface {...createDefaultProps({ gameState, gameCreator: 'player1' })} />);
+    expect(screen.getByText(/START GAME/)).toBeInTheDocument();
+  });
+
+  test('shows "Waiting for" message for non-creator in waiting state', () => {
+    const gameState = createMockGameState({ status: 'waiting' });
+    render(<GameInterface {...createDefaultProps({ gameState, gameCreator: 'otherPlayer' })} />);
+    expect(screen.getByText(/Waiting for the game creator/)).toBeInTheDocument();
+  });
+
+  test('start game sends POST request', async () => {
+    const mockFetch = mockFetchSuccess({ game_id: 'TEST1', status: 'active' });
+    const gameState = createMockGameState({ status: 'waiting' });
+    const onAddGameEvent = jest.fn();
+
+    render(
+      <GameInterface
+        {...createDefaultProps({ gameState, gameCreator: 'player1', onAddGameEvent })}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(/START GAME/));
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:5001/api/games/TEST1/start',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  test('child components are rendered', () => {
+    render(<GameInterface {...createDefaultProps()} />);
+    // LetterPool
+    expect(screen.getByText(/Available Letters/)).toBeInTheDocument();
+    // PlayerWords
+    expect(screen.getByText(/Players/)).toBeInTheDocument();
+    // WordInput
+    expect(screen.getByText(/Command Input/)).toBeInTheDocument();
+    // GameLog
+    expect(screen.getByText(/Game Log/)).toBeInTheDocument();
+  });
+
+  test('handleSubmitWord emits socket move event', () => {
+    render(<GameInterface {...createDefaultProps()} />);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'hello' } });
+    fireEvent.submit(input.closest('form'));
+
+    expect(mockSocket.emit).toHaveBeenCalledWith('move', { data: 'hello' });
+  });
+});

--- a/web/src/GameLobby.test.js
+++ b/web/src/GameLobby.test.js
@@ -1,0 +1,230 @@
+/**
+ * Tests for the GameLobby component.
+ * Verifies game list fetching, game creation, joining, and auto-refresh behavior.
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import GameLobby from './GameLobby';
+import { mockFetchSuccess, mockFetchError } from './testUtils';
+
+describe('GameLobby', () => {
+  const defaultProps = {
+    serverUrl: 'http://localhost:5001',
+    authToken: 'test-token',
+    onGameJoined: jest.fn(),
+    onGameCreated: jest.fn()
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    if (global.fetch) {
+      global.fetch = undefined;
+    }
+  });
+
+  const sampleGames = [
+    {
+      game_id: 'ABC123',
+      status: 'waiting',
+      max_players: 4,
+      current_players: [{ username: 'host', joined_at: '2025-01-15T10:00:00Z' }],
+      creator_id: 'uuid-1',
+      created_at: '2025-01-15T10:00:00Z',
+      started_at: null,
+      finished_at: null,
+      tileset: 'standard'
+    },
+    {
+      game_id: 'DEF456',
+      status: 'active',
+      max_players: 4,
+      current_players: [
+        { username: 'host2', joined_at: '2025-01-15T10:00:00Z' },
+        { username: 'guest', joined_at: '2025-01-15T10:01:00Z' }
+      ],
+      creator_id: 'uuid-2',
+      created_at: '2025-01-15T10:00:00Z',
+      started_at: '2025-01-15T10:02:00Z',
+      finished_at: null,
+      tileset: 'standard'
+    }
+  ];
+
+  test('fetches game list on mount', async () => {
+    const mockFetch = mockFetchSuccess({ games: sampleGames, total_games: 2 });
+
+    await act(async () => {
+      render(<GameLobby {...defaultProps} />);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:5001/api/games',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token'
+        })
+      })
+    );
+  });
+
+  test('renders game list with status and players', async () => {
+    mockFetchSuccess({ games: sampleGames, total_games: 2 });
+
+    await act(async () => {
+      render(<GameLobby {...defaultProps} />);
+    });
+
+    expect(screen.getByText(/ABC123/)).toBeInTheDocument();
+    expect(screen.getByText(/DEF456/)).toBeInTheDocument();
+    expect(screen.getByText(/WAITING/)).toBeInTheDocument();
+    expect(screen.getByText(/ACTIVE/)).toBeInTheDocument();
+  });
+
+  test('shows "No games available" for empty list', async () => {
+    mockFetchSuccess({ games: [], total_games: 0 });
+
+    await act(async () => {
+      render(<GameLobby {...defaultProps} />);
+    });
+
+    expect(screen.getByText(/No games available/)).toBeInTheDocument();
+  });
+
+  test('shows error on fetch failure', async () => {
+    mockFetchError(500, 'Server error');
+
+    await act(async () => {
+      render(<GameLobby {...defaultProps} />);
+    });
+
+    expect(screen.getByText(/Error/i)).toBeInTheDocument();
+  });
+
+  test('"Create New Game" toggles create panel', async () => {
+    mockFetchSuccess({ games: [], total_games: 0 });
+
+    await act(async () => {
+      render(<GameLobby {...defaultProps} />);
+    });
+
+    // Click to open create panel
+    const createBtn = screen.getByText(/Create New Game/);
+    fireEvent.click(createBtn);
+
+    // Tileset selector should appear
+    expect(screen.getByLabelText(/Tileset/)).toBeInTheDocument();
+
+    // Click again to close (button text changes to "Cancel")
+    const cancelBtn = screen.getByText('Cancel');
+    fireEvent.click(cancelBtn);
+
+    // Tileset selector should be gone
+    expect(screen.queryByLabelText(/Tileset/)).not.toBeInTheDocument();
+  });
+
+  test('creating a game sends POST with tileset', async () => {
+    // First call returns empty list, second call (after create) returns new game
+    let callCount = 0;
+    global.fetch = jest.fn(() => {
+      callCount++;
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          success: true,
+          data: callCount <= 1
+            ? { games: [], total_games: 0 }
+            : { game_id: 'NEW1', status: 'waiting' }
+        }),
+        text: () => Promise.resolve('{}')
+      });
+    });
+
+    await act(async () => {
+      render(<GameLobby {...defaultProps} />);
+    });
+
+    // Open create panel
+    fireEvent.click(screen.getByText(/Create New Game/));
+
+    // Click "Create Game" button
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create Game'));
+    });
+
+    // Should have made a POST call
+    const postCall = global.fetch.mock.calls.find(
+      call => call[1] && call[1].method === 'POST'
+    );
+    expect(postCall).toBeDefined();
+    expect(JSON.parse(postCall[1].body)).toHaveProperty('tileset', 'standard');
+  });
+
+  test('joining a game sends POST and calls onGameJoined', async () => {
+    // Setup: first fetch returns game list, then join succeeds
+    let callCount = 0;
+    global.fetch = jest.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ success: true, data: { games: sampleGames, total_games: 2 } }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ success: true, data: { game_id: 'ABC123', player_id: 'uuid', joined_at: '2025-01-15T10:05:00Z' } }),
+      });
+    });
+
+    await act(async () => {
+      render(<GameLobby {...defaultProps} />);
+    });
+
+    // Click "Join Game" on the waiting game
+    await act(async () => {
+      fireEvent.click(screen.getByText(/Join Game/));
+    });
+
+    expect(defaultProps.onGameJoined).toHaveBeenCalledWith(
+      'ABC123',
+      expect.objectContaining({ game_id: 'ABC123' })
+    );
+  });
+
+  test('auto-refreshes every 5 seconds', async () => {
+    const mockFetch = mockFetchSuccess({ games: [], total_games: 0 });
+
+    await act(async () => {
+      render(<GameLobby {...defaultProps} />);
+    });
+
+    const initialCallCount = mockFetch.mock.calls.length;
+
+    // Advance 5 seconds
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(mockFetch.mock.calls.length).toBeGreaterThan(initialCallCount);
+  });
+
+  test('clears interval on unmount', async () => {
+    mockFetchSuccess({ games: [], total_games: 0 });
+
+    let unmount;
+    await act(async () => {
+      const result = render(<GameLobby {...defaultProps} />);
+      unmount = result.unmount;
+    });
+
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+});

--- a/web/src/GameLog.test.js
+++ b/web/src/GameLog.test.js
@@ -1,0 +1,86 @@
+/**
+ * Tests for the GameLog component.
+ * Verifies message rendering, formatting, prefixes, and limiting behavior.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import GameLog from './GameLog';
+
+/**
+ * Helper to create a message object matching the format used by the app.
+ *
+ * Parameters
+ * ----------
+ * type : string
+ *     Message type (system, error, success, move, connection, game_event).
+ * text : string
+ *     Message text content.
+ * timestamp : number, optional
+ *     Unix timestamp in ms. Defaults to Date.now().
+ *
+ * Returns
+ * -------
+ * object
+ *     A message object with timestamp, type, and text fields.
+ */
+function makeMessage(type, text, timestamp = Date.now()) {
+  return { timestamp, type, text };
+}
+
+describe('GameLog', () => {
+  test('renders "Game Log" heading', () => {
+    render(<GameLog messages={[]} />);
+    expect(screen.getByText(/Game Log/)).toBeInTheDocument();
+  });
+
+  test('shows empty state when messages array is empty', () => {
+    render(<GameLog messages={[]} />);
+    expect(screen.getByText(/Game log is empty/)).toBeInTheDocument();
+  });
+
+  test('renders messages with [SYS] prefix for system type', () => {
+    const messages = [makeMessage('system', 'Welcome to the game')];
+    render(<GameLog messages={messages} />);
+    expect(screen.getByText(/\[SYS\].*Welcome to the game/)).toBeInTheDocument();
+  });
+
+  test('renders messages with correct prefixes per type', () => {
+    const messages = [
+      makeMessage('error', 'Something broke'),
+      makeMessage('success', 'Move worked'),
+      makeMessage('move', 'Playing HELLO'),
+      makeMessage('connection', 'player1 connected'),
+      makeMessage('game_event', 'Turn starting'),
+    ];
+    render(<GameLog messages={messages} />);
+
+    expect(screen.getByText(/\[ERR\].*Something broke/)).toBeInTheDocument();
+    expect(screen.getByText(/\[OK\].*Move worked/)).toBeInTheDocument();
+    expect(screen.getByText(/\[MOVE\].*Playing HELLO/)).toBeInTheDocument();
+    expect(screen.getByText(/\[CONN\].*player1 connected/)).toBeInTheDocument();
+    expect(screen.getByText(/\[GAME\].*Turn starting/)).toBeInTheDocument();
+  });
+
+  test('respects maxMessages prop', () => {
+    const messages = Array.from({ length: 10 }, (_, i) =>
+      makeMessage('system', `Message ${i}`)
+    );
+    render(<GameLog messages={messages} maxMessages={3} />);
+    // Should only show last 3 messages
+    expect(screen.queryByText(/Message 6/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Message 7/)).toBeInTheDocument();
+    expect(screen.getByText(/Message 8/)).toBeInTheDocument();
+    expect(screen.getByText(/Message 9/)).toBeInTheDocument();
+  });
+
+  test('shows timestamps on messages', () => {
+    // Use a fixed timestamp: 2025-01-15 at 14:30:45 UTC
+    const ts = new Date('2025-01-15T14:30:45Z').getTime();
+    const messages = [makeMessage('system', 'Test message', ts)];
+    render(<GameLog messages={messages} />);
+    // The formatted time should appear somewhere (locale-dependent, so use regex)
+    const messageEl = screen.getByText(/\[SYS\].*Test message/);
+    // Should contain a time pattern like HH:MM:SS
+    expect(messageEl.textContent).toMatch(/\d{2}:\d{2}:\d{2}/);
+  });
+});

--- a/web/src/GameOverScreen.test.js
+++ b/web/src/GameOverScreen.test.js
@@ -1,0 +1,127 @@
+/**
+ * Tests for the GameOverScreen component.
+ * Verifies game over display, winner announcement, scores, and countdown behavior.
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import GameOverScreen from './GameOverScreen';
+
+describe('GameOverScreen', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const defaultGameOverData = {
+    reason: 'All letters used',
+    final_scores: { player1: 45, player2: 38 },
+    winner: 'player1'
+  };
+
+  test('returns null when gameOverData is null', () => {
+    const { container } = render(
+      <GameOverScreen
+        gameOverData={null}
+        currentUsername="player1"
+        onReturnToLobby={jest.fn()}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('shows "GAME OVER!" text', () => {
+    render(
+      <GameOverScreen
+        gameOverData={defaultGameOverData}
+        currentUsername="player1"
+        onReturnToLobby={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/GAME OVER!/)).toBeInTheDocument();
+  });
+
+  test('shows "YOU WON!" when winner is current user', () => {
+    render(
+      <GameOverScreen
+        gameOverData={defaultGameOverData}
+        currentUsername="player1"
+        onReturnToLobby={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/YOU WON!/)).toBeInTheDocument();
+  });
+
+  test('shows winner name when winner is a different player', () => {
+    render(
+      <GameOverScreen
+        gameOverData={defaultGameOverData}
+        currentUsername="player2"
+        onReturnToLobby={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/player1 WINS!/)).toBeInTheDocument();
+  });
+
+  test('renders sorted final scores with ranks', () => {
+    render(
+      <GameOverScreen
+        gameOverData={defaultGameOverData}
+        currentUsername="spectator"
+        onReturnToLobby={jest.fn()}
+      />
+    );
+    // player1 has 45 (rank 1), player2 has 38 (rank 2)
+    expect(screen.getByText('45 pts')).toBeInTheDocument();
+    expect(screen.getByText('38 pts')).toBeInTheDocument();
+    expect(screen.getByText('#1')).toBeInTheDocument();
+    expect(screen.getByText('#2')).toBeInTheDocument();
+  });
+
+  test('shows "(You)" next to current player in scores', () => {
+    render(
+      <GameOverScreen
+        gameOverData={defaultGameOverData}
+        currentUsername="player2"
+        onReturnToLobby={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/player2/)).toBeInTheDocument();
+    expect(screen.getByText(/\(You\)/)).toBeInTheDocument();
+  });
+
+  test('countdown decrements each second', () => {
+    render(
+      <GameOverScreen
+        gameOverData={defaultGameOverData}
+        currentUsername="player1"
+        onReturnToLobby={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText(/5 seconds/)).toBeInTheDocument();
+
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(screen.getByText(/4 seconds/)).toBeInTheDocument();
+
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(screen.getByText(/3 seconds/)).toBeInTheDocument();
+  });
+
+  test('"Return to Lobby Now" button calls onReturnToLobby', () => {
+    const onReturn = jest.fn();
+    render(
+      <GameOverScreen
+        gameOverData={defaultGameOverData}
+        currentUsername="player1"
+        onReturnToLobby={onReturn}
+      />
+    );
+
+    const button = screen.getByText('Return to Lobby Now');
+    button.click();
+    expect(onReturn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/LetterPool.js
+++ b/web/src/LetterPool.js
@@ -3,13 +3,7 @@
  * Shows individual letter tiles with their point values from Scrabble scoring.
  */
 import React from 'react';
-
-// Scrabble letter point values
-const LETTER_POINTS = {
-  'a': 1, 'b': 3, 'c': 3, 'd': 2, 'e': 1, 'f': 4, 'g': 2, 'h': 4, 'i': 1, 'j': 8,
-  'k': 5, 'l': 1, 'm': 3, 'n': 1, 'o': 1, 'p': 3, 'q': 10, 'r': 1, 's': 1, 't': 1,
-  'u': 1, 'v': 4, 'w': 4, 'x': 8, 'y': 4, 'z': 10
-};
+import { LETTER_POINTS } from './utils';
 
 function LetterPool({ pool }) {
   if (!pool || !Array.isArray(pool)) {

--- a/web/src/LetterPool.test.js
+++ b/web/src/LetterPool.test.js
@@ -1,0 +1,81 @@
+/**
+ * Tests for the LetterPool component.
+ * Verifies rendering of letter tiles, point values, and edge cases.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import LetterPool from './LetterPool';
+
+describe('LetterPool', () => {
+  test('renders "Available Letters" heading', () => {
+    render(<LetterPool pool={[]} />);
+    expect(screen.getByText(/Available Letters/)).toBeInTheDocument();
+  });
+
+  test('shows "No letters available" when pool is null', () => {
+    render(<LetterPool pool={null} />);
+    expect(screen.getByText(/No letters available/)).toBeInTheDocument();
+  });
+
+  test('shows "No letters available" when pool is undefined', () => {
+    render(<LetterPool />);
+    expect(screen.getByText(/No letters available/)).toBeInTheDocument();
+  });
+
+  test('shows "Pool is empty" when all counts are zero', () => {
+    const emptyPool = new Array(26).fill(0);
+    render(<LetterPool pool={emptyPool} />);
+    expect(screen.getByText(/Pool is empty/)).toBeInTheDocument();
+  });
+
+  test('renders correct number of tiles for a pool array', () => {
+    // a=1, c=2 => 3 tiles total
+    const pool = [1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    render(<LetterPool pool={pool} />);
+    const tiles = document.querySelectorAll('.letter-tile');
+    expect(tiles).toHaveLength(3);
+  });
+
+  test('renders correct uppercase letter on tile', () => {
+    // a=1 only
+    const pool = [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    render(<LetterPool pool={pool} />);
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+
+  test('renders point value on tile', () => {
+    // q=1 (index 16, points=10)
+    const pool = new Array(26).fill(0);
+    pool[16] = 1; // q
+    render(<LetterPool pool={pool} />);
+    expect(screen.getByText('Q')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+  });
+
+  test('renders multiple copies of the same letter', () => {
+    // a=2
+    const pool = [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    render(<LetterPool pool={pool} />);
+    const tiles = document.querySelectorAll('.letter-tile');
+    expect(tiles).toHaveLength(2);
+    // Both should show 'A'
+    const letterChars = document.querySelectorAll('.letter-char');
+    letterChars.forEach(el => {
+      expect(el.textContent).toBe('A');
+    });
+  });
+
+  test('renders mixed letters in alphabetical order', () => {
+    // a=1, e=1, z=1
+    const pool = new Array(26).fill(0);
+    pool[0] = 1;  // a
+    pool[4] = 1;  // e
+    pool[25] = 1; // z
+    render(<LetterPool pool={pool} />);
+    const letterChars = document.querySelectorAll('.letter-char');
+    expect(letterChars).toHaveLength(3);
+    expect(letterChars[0].textContent).toBe('A');
+    expect(letterChars[1].textContent).toBe('E');
+    expect(letterChars[2].textContent).toBe('Z');
+  });
+});

--- a/web/src/PlayerWords.js
+++ b/web/src/PlayerWords.js
@@ -3,13 +3,7 @@
  * Shows each player's word collection with individual word scores and total scores.
  */
 import React from 'react';
-
-// Scrabble letter point values
-const LETTER_POINTS = {
-  'a': 1, 'b': 3, 'c': 3, 'd': 2, 'e': 1, 'f': 4, 'g': 2, 'h': 4, 'i': 1, 'j': 8,
-  'k': 5, 'l': 1, 'm': 3, 'n': 1, 'o': 1, 'p': 3, 'q': 10, 'r': 1, 's': 1, 't': 1,
-  'u': 1, 'v': 4, 'w': 4, 'x': 8, 'y': 4, 'z': 10
-};
+import { SCRABBLE_POINTS as LETTER_POINTS, calculateWordScore } from './utils';
 
 function PlayerWords({ players, gameState, currentUsername, finalScores = null }) {
   if (!players || !gameState) {
@@ -20,13 +14,6 @@ function PlayerWords({ players, gameState, currentUsername, finalScores = null }
       </div>
     );
   }
-
-  // Calculate word score
-  const calculateWordScore = (word) => {
-    return word.toLowerCase().split('').reduce((sum, letter) => {
-      return sum + (LETTER_POINTS[letter] || 0);
-    }, 0);
-  };
 
   // Parse game state to get words per player
   let parsedState = {};

--- a/web/src/PlayerWords.test.js
+++ b/web/src/PlayerWords.test.js
@@ -1,0 +1,132 @@
+/**
+ * Tests for the PlayerWords component.
+ * Verifies player display, word rendering, scores, and edge cases.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PlayerWords from './PlayerWords';
+import { createMockGameState, createMockPlayers } from './testUtils';
+
+describe('PlayerWords', () => {
+  test('renders player usernames', () => {
+    const gameState = createMockGameState();
+    render(
+      <PlayerWords
+        players={gameState.players}
+        gameState={gameState}
+        currentUsername="player1"
+      />
+    );
+    expect(screen.getByText(/player1/)).toBeInTheDocument();
+    expect(screen.getByText(/player2/)).toBeInTheDocument();
+  });
+
+  test('highlights current player with "(You)"', () => {
+    const gameState = createMockGameState();
+    render(
+      <PlayerWords
+        players={gameState.players}
+        gameState={gameState}
+        currentUsername="player1"
+      />
+    );
+    expect(screen.getByText(/\(You\)/)).toBeInTheDocument();
+  });
+
+  test('shows Online/Offline status', () => {
+    const players = {
+      player1: { connected: true, score: 0, ready_for_next_turn: false },
+      player2: { connected: false, score: 0, ready_for_next_turn: false }
+    };
+    const gameState = createMockGameState({ players });
+    render(
+      <PlayerWords
+        players={players}
+        gameState={gameState}
+        currentUsername="player1"
+      />
+    );
+    expect(screen.getByText(/Online/)).toBeInTheDocument();
+    expect(screen.getByText(/Offline/)).toBeInTheDocument();
+  });
+
+  test('shows "No words yet" for empty word list', () => {
+    const gameState = createMockGameState({}, { words_per_player: [[], []] });
+    render(
+      <PlayerWords
+        players={gameState.players}
+        gameState={gameState}
+        currentUsername="player1"
+      />
+    );
+    const noWordsEls = screen.getAllByText(/No words yet/);
+    expect(noWordsEls).toHaveLength(2);
+  });
+
+  test('renders word tiles with uppercase text', () => {
+    const gameState = createMockGameState({}, { words_per_player: [['hello'], ['world']] });
+    render(
+      <PlayerWords
+        players={gameState.players}
+        gameState={gameState}
+        currentUsername="player1"
+      />
+    );
+    expect(screen.getByText('HELLO')).toBeInTheDocument();
+    expect(screen.getByText('WORLD')).toBeInTheDocument();
+  });
+
+  test('renders calculated word scores next to words', () => {
+    // hello = h(4)+e(1)+l(1)+l(1)+o(1) = 8
+    const gameState = createMockGameState({}, { words_per_player: [['hello'], []] });
+    render(
+      <PlayerWords
+        players={gameState.players}
+        gameState={gameState}
+        currentUsername="player1"
+      />
+    );
+    expect(screen.getByText('HELLO')).toBeInTheDocument();
+    // Word score chip should show "8"
+    expect(screen.getByText('8')).toBeInTheDocument();
+  });
+
+  test('shows player total scores', () => {
+    const gameState = createMockGameState({}, { scores: [15, 23] });
+    render(
+      <PlayerWords
+        players={gameState.players}
+        gameState={gameState}
+        currentUsername="player1"
+      />
+    );
+    expect(screen.getByText('15 pts')).toBeInTheDocument();
+    expect(screen.getByText('23 pts')).toBeInTheDocument();
+  });
+
+  test('handles null/missing game state gracefully', () => {
+    render(
+      <PlayerWords
+        players={null}
+        gameState={null}
+        currentUsername="player1"
+      />
+    );
+    expect(screen.getByText(/No game data available/)).toBeInTheDocument();
+  });
+
+  test('handles state as JSON string', () => {
+    const gameState = createMockGameState();
+    // state is already a JSON string from createMockGameState
+    expect(typeof gameState.state).toBe('string');
+    render(
+      <PlayerWords
+        players={gameState.players}
+        gameState={gameState}
+        currentUsername="player1"
+      />
+    );
+    // Should parse and render without errors
+    expect(screen.getByText('HELLO')).toBeInTheDocument();
+  });
+});

--- a/web/src/WordInput.test.js
+++ b/web/src/WordInput.test.js
@@ -1,0 +1,188 @@
+/**
+ * Tests for the WordInput component.
+ * Verifies word submission, command handling, input validation, and keyboard navigation.
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import WordInput from './WordInput';
+import { mockFetchSuccess, mockFetchError } from './testUtils';
+
+describe('WordInput', () => {
+  const defaultProps = {
+    onSubmitWord: jest.fn(),
+    onPass: jest.fn(),
+    disabled: false,
+    gameId: 'TEST1',
+    currentUsername: 'player1',
+    authToken: 'test-token',
+    serverUrl: 'http://localhost:5001',
+    gameCreator: 'player1',
+    onAddGameEvent: jest.fn()
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    if (global.fetch) {
+      global.fetch = undefined;
+    }
+  });
+
+  afterEach(() => {
+    console.log.mockRestore();
+    console.error.mockRestore();
+  });
+
+  test('renders prompt with game ID and username', () => {
+    render(<WordInput {...defaultProps} />);
+    expect(screen.getByText(/TEST1/)).toBeInTheDocument();
+    expect(screen.getByText(/@player1/)).toBeInTheDocument();
+  });
+
+  test('submitting a word calls onSubmitWord with lowercase word', () => {
+    render(<WordInput {...defaultProps} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'Hello' } });
+    fireEvent.submit(input.closest('form'));
+
+    expect(defaultProps.onSubmitWord).toHaveBeenCalledWith('hello');
+  });
+
+  test('submitting empty input calls onPass', () => {
+    render(<WordInput {...defaultProps} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.submit(input.closest('form'));
+
+    expect(defaultProps.onPass).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onSubmitWord).not.toHaveBeenCalled();
+  });
+
+  test('!ready calls onPass', () => {
+    render(<WordInput {...defaultProps} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: '!ready' } });
+    fireEvent.submit(input.closest('form'));
+
+    expect(defaultProps.onPass).toHaveBeenCalledTimes(1);
+  });
+
+  test('!help calls onAddGameEvent with system type', () => {
+    render(<WordInput {...defaultProps} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: '!help' } });
+    fireEvent.submit(input.closest('form'));
+
+    expect(defaultProps.onAddGameEvent).toHaveBeenCalledWith(
+      'system',
+      expect.stringContaining('Commands:')
+    );
+  });
+
+  test('invalid input calls onAddGameEvent with error type', () => {
+    render(<WordInput {...defaultProps} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'abc123' } });
+    fireEvent.submit(input.closest('form'));
+
+    expect(defaultProps.onAddGameEvent).toHaveBeenCalledWith(
+      'error',
+      expect.stringContaining('Invalid command')
+    );
+  });
+
+  test('input is cleared after submission', () => {
+    render(<WordInput {...defaultProps} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'hello' } });
+    fireEvent.submit(input.closest('form'));
+
+    expect(input.value).toBe('');
+  });
+
+  test('disabled state prevents submission', () => {
+    render(<WordInput {...defaultProps} disabled={true} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'hello' } });
+    fireEvent.submit(input.closest('form'));
+
+    expect(defaultProps.onSubmitWord).not.toHaveBeenCalled();
+  });
+
+  test('ArrowUp/ArrowDown navigate command history', () => {
+    render(<WordInput {...defaultProps} />);
+    const input = screen.getByRole('textbox');
+
+    // Submit two commands to build history
+    fireEvent.change(input, { target: { value: 'first' } });
+    fireEvent.submit(input.closest('form'));
+
+    fireEvent.change(input, { target: { value: 'second' } });
+    fireEvent.submit(input.closest('form'));
+
+    // ArrowUp should show most recent command
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(input.value).toBe('second');
+
+    // ArrowUp again should show older command
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(input.value).toBe('first');
+
+    // ArrowDown should go back to more recent
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(input.value).toBe('second');
+
+    // ArrowDown again should clear input
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(input.value).toBe('');
+  });
+
+  test('!end sends DELETE fetch when user is creator', async () => {
+    const mockFetch = mockFetchSuccess({ game_id: 'TEST1', status: 'finished' });
+
+    render(<WordInput {...defaultProps} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: '!end' } });
+    fireEvent.submit(input.closest('form'));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:5001/api/games/TEST1',
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
+  });
+
+  test('!end by non-creator shows error', () => {
+    render(<WordInput {...defaultProps} gameCreator="otherPlayer" />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: '!end' } });
+    fireEvent.submit(input.closest('form'));
+
+    expect(defaultProps.onAddGameEvent).toHaveBeenCalledWith(
+      'error',
+      expect.stringContaining('Only the game creator')
+    );
+  });
+
+  test('recent commands are displayed', () => {
+    render(<WordInput {...defaultProps} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'hello' } });
+    fireEvent.submit(input.closest('form'));
+
+    expect(screen.getByText(/Recent:/)).toBeInTheDocument();
+    expect(screen.getByText(/hello/)).toBeInTheDocument();
+  });
+});

--- a/web/src/setupTests.js
+++ b/web/src/setupTests.js
@@ -3,3 +3,6 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// jsdom does not implement scrollIntoView, so we mock it globally for all tests.
+Element.prototype.scrollIntoView = jest.fn();

--- a/web/src/testUtils.js
+++ b/web/src/testUtils.js
@@ -1,0 +1,171 @@
+/**
+ * Shared test utilities and fixtures for frontend unit tests.
+ * Provides mock factories for sockets, fetch, and game state objects.
+ */
+
+/**
+ * Create a mock Socket.IO socket object with event simulation support.
+ *
+ * Returns
+ * -------
+ * object
+ *     Mock socket with on, emit, connect, disconnect as jest.fn()s,
+ *     plus simulateEvent(name, data) to invoke registered handlers.
+ */
+export function createMockSocket() {
+  const handlers = {};
+
+  const socket = {
+    on: jest.fn((event, handler) => {
+      if (!handlers[event]) {
+        handlers[event] = [];
+      }
+      handlers[event].push(handler);
+    }),
+    emit: jest.fn(),
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    connected: true,
+
+    /**
+     * Fire all handlers registered for a given event.
+     *
+     * Parameters
+     * ----------
+     * event : string
+     *     The event name.
+     * data : any
+     *     The payload to pass to each handler.
+     */
+    simulateEvent: (event, data) => {
+      if (handlers[event]) {
+        handlers[event].forEach(handler => handler(data));
+      }
+    },
+
+    /**
+     * Clear all registered event handlers.
+     */
+    resetHandlers: () => {
+      Object.keys(handlers).forEach(key => delete handlers[key]);
+    }
+  };
+
+  return socket;
+}
+
+/**
+ * Set up global.fetch to return a successful JSON response.
+ *
+ * Parameters
+ * ----------
+ * data : object
+ *     The data field to include in the { success: true, data } response.
+ *
+ * Returns
+ * -------
+ * jest.Mock
+ *     The mock fetch function for additional assertions.
+ */
+export function mockFetchSuccess(data) {
+  const mockFetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ success: true, data }),
+      text: () => Promise.resolve(JSON.stringify({ success: true, data }))
+    })
+  );
+  global.fetch = mockFetch;
+  return mockFetch;
+}
+
+/**
+ * Set up global.fetch to return an error response.
+ *
+ * Parameters
+ * ----------
+ * status : number
+ *     HTTP status code (e.g. 400, 500).
+ * error : string
+ *     Error message to include in the response body.
+ *
+ * Returns
+ * -------
+ * jest.Mock
+ *     The mock fetch function for additional assertions.
+ */
+export function mockFetchError(status, error) {
+  const mockFetch = jest.fn(() =>
+    Promise.resolve({
+      ok: false,
+      status,
+      json: () => Promise.resolve({ success: false, error }),
+      text: () => Promise.resolve(JSON.stringify({ success: false, error }))
+    })
+  );
+  global.fetch = mockFetch;
+  return mockFetch;
+}
+
+/**
+ * Create a realistic mock game state object with sensible defaults.
+ * The state field is a JSON string matching the server's format.
+ *
+ * Parameters
+ * ----------
+ * overrides : object, optional
+ *     Properties to override on the top-level game state object.
+ * stateOverrides : object, optional
+ *     Properties to override within the parsed state (pool, bag, words_per_player, etc.).
+ *
+ * Returns
+ * -------
+ * object
+ *     A game state object matching the server's game_state event format.
+ */
+export function createMockGameState(overrides = {}, stateOverrides = {}) {
+  const innerState = {
+    num_players: 2,
+    pool: [1, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    bag: [7, 2, 1, 3, 10, 2, 2, 2, 8, 1, 1, 3, 2, 5, 7, 2, 1, 5, 3, 5, 3, 2, 2, 1, 2, 1],
+    words_per_player: [['hello'], ['world']],
+    scores: [8, 9],
+    passed: [false, false],
+    ...stateOverrides
+  };
+
+  return {
+    game_id: 'TEST1',
+    game_type: 'grab',
+    status: 'active',
+    current_turn: 1,
+    turn_time_remaining: null,
+    players: {
+      player1: { connected: true, score: 8, ready_for_next_turn: false },
+      player2: { connected: true, score: 9, ready_for_next_turn: false }
+    },
+    state: JSON.stringify(innerState),
+    ...overrides
+  };
+}
+
+/**
+ * Create a mock players map with defaults.
+ *
+ * Parameters
+ * ----------
+ * overrides : object, optional
+ *     Properties to merge into the default players map.
+ *
+ * Returns
+ * -------
+ * object
+ *     A players map keyed by username with connected, score, and ready_for_next_turn fields.
+ */
+export function createMockPlayers(overrides = {}) {
+  return {
+    player1: { connected: true, score: 8, ready_for_next_turn: false },
+    player2: { connected: true, score: 9, ready_for_next_turn: false },
+    ...overrides
+  };
+}

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -1,0 +1,37 @@
+/**
+ * Shared utility constants and functions for the Grab game frontend.
+ * Extracted from LetterPool.js and PlayerWords.js to avoid duplication.
+ */
+
+/**
+ * Scrabble letter point values.
+ * Maps each lowercase letter to its standard Scrabble tile point value.
+ */
+export const SCRABBLE_POINTS = {
+  'a': 1, 'b': 3, 'c': 3, 'd': 2, 'e': 1, 'f': 4, 'g': 2, 'h': 4, 'i': 1, 'j': 8,
+  'k': 5, 'l': 1, 'm': 3, 'n': 1, 'o': 1, 'p': 3, 'q': 10, 'r': 1, 's': 1, 't': 1,
+  'u': 1, 'v': 4, 'w': 4, 'x': 8, 'y': 4, 'z': 10
+};
+
+// Alias for backward compatibility (LetterPool uses LETTER_POINTS)
+export const LETTER_POINTS = SCRABBLE_POINTS;
+
+/**
+ * Calculate the Scrabble score for a word.
+ *
+ * Parameters
+ * ----------
+ * word : string
+ *     The word to score. Case-insensitive.
+ *
+ * Returns
+ * -------
+ * number
+ *     The sum of Scrabble point values for each letter in the word.
+ *     Unknown characters contribute 0 points.
+ */
+export function calculateWordScore(word) {
+  return word.toLowerCase().split('').reduce((sum, letter) => {
+    return sum + (SCRABBLE_POINTS[letter] || 0);
+  }, 0);
+}

--- a/web/src/utils.test.js
+++ b/web/src/utils.test.js
@@ -1,0 +1,51 @@
+/**
+ * Tests for shared utility constants and functions.
+ */
+import { SCRABBLE_POINTS, LETTER_POINTS, calculateWordScore } from './utils';
+
+describe('SCRABBLE_POINTS', () => {
+  test('has entries for all 26 letters', () => {
+    expect(Object.keys(SCRABBLE_POINTS)).toHaveLength(26);
+    for (let i = 0; i < 26; i++) {
+      const letter = String.fromCharCode(97 + i);
+      expect(SCRABBLE_POINTS).toHaveProperty(letter);
+      expect(typeof SCRABBLE_POINTS[letter]).toBe('number');
+    }
+  });
+
+  test('has correct values for known letters', () => {
+    expect(SCRABBLE_POINTS['a']).toBe(1);
+    expect(SCRABBLE_POINTS['q']).toBe(10);
+    expect(SCRABBLE_POINTS['z']).toBe(10);
+    expect(SCRABBLE_POINTS['x']).toBe(8);
+    expect(SCRABBLE_POINTS['k']).toBe(5);
+  });
+
+  test('LETTER_POINTS is the same object as SCRABBLE_POINTS', () => {
+    expect(LETTER_POINTS).toBe(SCRABBLE_POINTS);
+  });
+});
+
+describe('calculateWordScore', () => {
+  test('calculates score for "hello"', () => {
+    // h=4, e=1, l=1, l=1, o=1 = 8
+    expect(calculateWordScore('hello')).toBe(8);
+  });
+
+  test('returns 0 for empty string', () => {
+    expect(calculateWordScore('')).toBe(0);
+  });
+
+  test('is case-insensitive', () => {
+    expect(calculateWordScore('HELLO')).toBe(calculateWordScore('hello'));
+  });
+
+  test('calculates score for high-value word', () => {
+    // q=10, u=1, i=1, z=10 = 22
+    expect(calculateWordScore('quiz')).toBe(22);
+  });
+
+  test('returns 0 for non-letter characters', () => {
+    expect(calculateWordScore('123')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 83 unit tests across 9 test suites covering all frontend components
- Extract shared `SCRABBLE_POINTS` and `calculateWordScore` to `web/src/utils.js` to deduplicate code in LetterPool.js and PlayerWords.js
- Add shared test utilities (`testUtils.js`) with mock factories for Socket.IO, fetch, and game state
- Add `@testing-library/jest-dom`, `@testing-library/react`, and `@testing-library/user-event` as explicit devDependencies

## Test plan
- [x] All 83 frontend tests pass (`cd web && npx react-scripts test --watchAll=false`)
- [x] All 191 Python tests pass (`uv run pytest`)
- [ ] After merging, run `cd web && npm install` to install new devDependencies, then verify tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)